### PR TITLE
Allow to not display admin link on admin home

### DIFF
--- a/src/components/admin/home.js
+++ b/src/components/admin/home.js
@@ -34,7 +34,7 @@ class Home extends React.Component {
             <div className="admin-home-group" key={`admin-home-group-${index}`}>
               {group.label ? <h1>{group.label}</h1> : null}
                 <div className="admin-home-group-items">
-                {group.items.filter(item => item.display !== false).map((item, index) => {
+                {group.items.filter(item => item.display !== false && item.displayOnHome !== false).map((item, index) => {
                   return [<Link to={"/admin/" + item.route}>
                             <div className={`admin-home-item ${item.class || item.faIcon}`} key={`admin-home-item-${index}`}>
                               <h2>{item.title}</h2>


### PR DESCRIPTION
But keep it in navbar

J'ai un item que je veux voir apparaître dans la navbar mais pas dans la home de l'admin. J'ai pensé à cela mais ne suis pas sûr que ce soit le moyen le plus élégant.